### PR TITLE
Add atmos vpn and speedup provisioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+files/system/usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm.encrypted.xz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,7 +37,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "Running testing-farm"
-          testing-farm request -e IMAGE_TAG=${GITHUB_HEAD_REF} --plan /ci/build --compose Fedora-latest
+          testing-farm request -e IMAGE_TAG=${GITHUB_HEAD_REF} --plan /ci/build --compose Fedora-latest --skip-guest-setup
 
       - name: Run testing-farm (schedule/manual)
         env:
@@ -45,4 +45,4 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Running testing-farm with IMAGE_TAG=$IMAGE_TAG"
-          testing-farm request --plan /build --compose Fedora-latest
+          testing-farm request --plan /build --compose Fedora-latest --skip-guest-setup

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 # Cosign private key
 cosign.private
 
+# Compressed files
+files/system/usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm.encrypted
+
 # Decrypted files
 files/system/etc/NetworkManager/system-connections/*.nmconnection
 files/system/etc/pki/ca-trust/source/anchors/Current-IT-Root-CAs.pem
 files/system/etc/ssl/nordvpn/*.pem
+files/system/usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm
 
 # This file is created by direnv
 .vault_pass

--- a/.justfile
+++ b/.justfile
@@ -14,6 +14,10 @@ all: decrypt build test login push
 
 # Decrypt secret files
 decrypt:
+    @for file in $(find . -name *.encrypted.xz); do \
+      echo "Unpacking encrypted file '$file' ..."; \
+      xz -dk $file; \
+    done
     @for file in $(find . -name *.encrypted); do \
       echo "Decrypting file '$file' ..."; \
       ansible-vault decrypt --output ${file%.encrypted} $file; \

--- a/files/system/etc/fonts/conf.d/99-noto-color-emoji-override.conf
+++ b/files/system/etc/fonts/conf.d/99-noto-color-emoji-override.conf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <!-- Ensure Noto Color Emoji is preferred for emoji codepoints.
+       Without this, Font Awesome (which covers some emoji codepoints)
+       can win the charset-based fallback match, resulting in missing
+       color emoji in applications like Chrome. -->
+
+  <!-- Add Noto Color Emoji as a default fallback for common font families -->
+  <alias binding="strong">
+    <family>sans-serif</family>
+    <default>
+      <family>Noto Color Emoji</family>
+    </default>
+  </alias>
+  <alias binding="strong">
+    <family>serif</family>
+    <default>
+      <family>Noto Color Emoji</family>
+    </default>
+  </alias>
+  <alias binding="strong">
+    <family>monospace</family>
+    <default>
+      <family>Noto Color Emoji</family>
+    </default>
+  </alias>
+
+  <!-- Assign Noto Color Emoji to the emoji generic family with high priority -->
+  <alias binding="strong">
+    <family>emoji</family>
+    <prefer>
+      <family>Noto Color Emoji</family>
+    </prefer>
+  </alias>
+</fontconfig>

--- a/files/system/usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm.encrypted.xz
+++ b/files/system/usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm.encrypted.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba251c821c84a3ada6930d47b7d846539feae20bb540f0b0389608c3f923d891
+size 213184012

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -8,6 +8,11 @@ base-image: quay.io/fedora-ostree-desktops/sway-atomic
 image-version: 43
 
 modules:
+  - type: files
+    files:
+      - source: system
+        destination: /
+
   - type: rpm-ostree
     install:
       - copyq
@@ -16,15 +21,11 @@ modules:
       - nautilus
       - https://gitlab.com/mvadkert/xerox-3020/-/raw/main/xerox-3020-1.0.0-1.x86_64.rpm
       - https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+      - /usr/share/rpms/nvidia.atmos-agent-3.96.5.x86_64.rpm
 
   - type: bling
     install:
       - rpmfusion
-
-  - type: files
-    files:
-      - source: system
-        destination: /
 
   - type: fonts
     fonts:


### PR DESCRIPTION
## Summary by Sourcery

Include encrypted atmos VPN RPM and fontconfig override files in the image build and adjust CI and local tooling to handle them efficiently.

New Features:
- Bundle an encrypted nvidia atmos agent RPM into the image and install it via rpm-ostree.
- Add a fontconfig override to prefer Noto Color Emoji for emoji rendering across common font families.

Enhancements:
- Move system file injection earlier in the image recipe to support newly added assets.
- Speed up local decryption by automatically decompressing .encrypted.xz files before running ansible-vault.

CI:
- Update Testing Farm CI workflow to skip guest setup for both PR and scheduled/manual runs.